### PR TITLE
Nominate developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,14 @@ publishing {
                 }
 
                 developers {
+                    developer {
+                        name = "Vinh Vo"
+                        email = "vinhvd@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
                 }
 
                 scm {


### PR DESCRIPTION
We're going to release JARs of `embulk-filter-decrypt` to Maven Central from 0.2.0 (#6).

Maven Central needs the `<developers>` section available in `pom.xml`. Having the contributing developer there explicitly.